### PR TITLE
User active/inactive be

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,12 +8,13 @@ datasource db {
 }
 
 model user_info {
-  userId      String   @id @default(cuid())
-  userName    String   @unique
-  email       String   @unique
-  password    String
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @default(now())
+  userId      String       @id @default(cuid())
+  userName    String       @unique
+  email       String       @unique
+  password    String    
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @default(now())
+  status      OnlineStatus @default(OFFLINE)
 
   // Relation with friend_request
   sentRequests      friend_request[] @relation("Sender")
@@ -24,6 +25,12 @@ enum FriendRequestStatus {
   PENDING
   ACCEPTED
   DECLINED
+}
+
+enum OnlineStatus{
+  OFFLINE
+  INACTIVE
+  ONLINE
 }
 
 model friend_request {

--- a/backend/src/routes/Login.ts
+++ b/backend/src/routes/Login.ts
@@ -33,13 +33,16 @@ export default async function loginRoutes(app: FastifyInstance) {
             return reply.status(401).send(errorResponse(401, "Invalid credentials."));
         }
 
+        
         setCookies(reply, user.userId);
-        //TODO: toggle person online in the database
+        
         const responseUser = {
             userId: user.userId,
             userName: user.userName,
         };
-
+        
+        await prisma.user_info.update({ where: { userId: user.userId }, data: { status: 'ONLINE' } }); //TODO: Wrap in try/catch
+        
         return reply.status(200).send(loginSuccess(responseUser));
     });
 }

--- a/backend/src/routes/Logout.ts
+++ b/backend/src/routes/Logout.ts
@@ -24,13 +24,16 @@ export default async function logoutRoutes(app: FastifyInstance) {
            return reply.status(401).send(errorResponse(401, "User does not exist"));
         }
 
+        
         clearCookies(reply);
-
-        //TODO: toggle person offline in the database
+        
         const responseUser = {
             userId: user.userId,
             userName: user.userName,
         };
+
+        await prisma.user_info.update({ where: { userId: user.userId }, data: { status: 'OFFLINE' } }); //TODO: Wrap in try/catch
+
         return reply.status(200).send(logoutSuccess(responseUser));
     });
 }

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -77,7 +77,7 @@ export function clearCookies(reply: FastifyReply)
     reply.clearCookie("accessJWT", {
         path: "/",
     });
-    reply.clearCookie("refreshJWT" {
+    reply.clearCookie("refreshJWT", {
         path: "/auth/refresh",
     });
 }


### PR DESCRIPTION
Prisma user schema now has a variable to track user's online status.

The following statuses are now available: online, inactive, offline.

I implemented switches to login and logout to mark person online/offline.

Inactive status is currently unused.