### PR TITLE
Https connection

### DIFF
--- a/frontend/src/utils/apiClient.ts
+++ b/frontend/src/utils/apiClient.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const apiClient = axios.create({
-	baseURL: 'http://localhost:3000',
+	baseURL: '',
 	withCredentials: true,
 	headers: {
 		'Content-Type': 'application/json',

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -41,6 +41,7 @@ http {
         location / {
             proxy_pass http://frontend:5173/;
             proxy_http_version 1.1;
+            proxy_set_header Host $host;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection 'upgrade';
             proxy_cache_bypass $http_upgrade;

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -40,6 +40,10 @@ http {
 
         location / {
             proxy_pass http://frontend:5173/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_cache_bypass $http_upgrade;
         }
     }
 }


### PR DESCRIPTION
Shipping small changes to fix big issues.

Changed the baseURL to '' in apiClient.
apiClient tried to connect to backend directly through port 3000, now the request goes through nginx.
Reason for this is that the route '/api/something/something' is already declared when sending requests,
baseURL serves no purpose.

By removing '/api' portion in the requests on frontend, baseURL could be changed to '/api'.
This could be a good idea for clear documentation.

Added ajdustments in nginx.conf too accomodate vite's needs.
Vite.config might need to also be looked at on the frontend, but atleast everything seems to run now.